### PR TITLE
Do not merge

### DIFF
--- a/app/lib/experiments-client.coffee
+++ b/app/lib/experiments-client.coffee
@@ -1,0 +1,274 @@
+# For managing experiments and interactions with the Experiment Server, and maintaining the current experiment state
+
+config = require './experiments-config'
+{getSessionID} = require '../lib/session'
+DEBUG = false
+
+class ExperimentsClient # Client for the ExperimentServer
+
+  EXPERIMENT_STATE_CLASSIFYING: "classifying"
+  EXPERIMENT_STATE_POST_CLASSIFY: "classified"
+  EXPERIMENT_STATE_INTERVENTION_ON_SCREEN: "intervening"
+  EXPERIMENT_STATE_WHATS_NEXT: "in-between"
+  EXPERIMENT_STATE_FINISHED: "finished"
+
+  EXPERIMENT_SERVER_PRODUCTION_URL: "https://experiments.zooniverse.org"
+  EXPERIMENT_SERVER_STAGING_URL: "https://experiments.staging.zooniverse.org"
+  #EXPERIMENT_SERVER_DEVELOPMENT_URL: "http://localhost:4567"
+  EXPERIMENT_SERVER_URL_TO_USE: null
+
+  currentExperimentState: @EXPERIMENT_STATE_WHATS_NEXT
+  # TODO As soon as we support more than one PFE experiment at once (even if on different projects) we'll need to
+  # update this class so that it can handle different state for different experiments at the same time.
+  # The better approach will be to move this responsibility to the Experiment Server. See
+  # https://github.com/zooniverse/experiment-server/issues/31
+
+  ensureEnvironmentSet: ->
+    if not @EXPERIMENT_SERVER_URL_TO_USE?
+      if window.location.hostname is "www.zooniverse.org"
+        @EXPERIMENT_SERVER_URL_TO_USE = @EXPERIMENT_SERVER_PRODUCTION_URL
+      #else if window.location.hostname is "localhost"
+      #  @EXPERIMENT_SERVER_URL_TO_USE = @EXPERIMENT_SERVER_DEVELOPMENT_URL
+      else
+        @EXPERIMENT_SERVER_URL_TO_USE = @EXPERIMENT_SERVER_STAGING_URL
+    @EXPERIMENT_SERVER_URL_TO_USE
+  
+  getEnabledExperiments: ->
+    @ensureEnvironmentSet()
+    switch @EXPERIMENT_SERVER_URL_TO_USE
+      when @EXPERIMENT_SERVER_PRODUCTION_URL
+        config.ENABLED_EXPERIMENTS_PRODUCTION
+      else
+        config.ENABLED_EXPERIMENTS_STAGING
+
+  getInterventionDetails: ->
+    @ensureEnvironmentSet()
+    switch @EXPERIMENT_SERVER_URL_TO_USE
+      when @EXPERIMENT_SERVER_PRODUCTION_URL
+        config.INTERVENTION_DETAILS_PRODUCTION
+      else
+        config.INTERVENTION_DETAILS_STAGING
+
+  getProjectSlugs: ->
+    @ensureEnvironmentSet()
+    switch @EXPERIMENT_SERVER_URL_TO_USE
+      when @EXPERIMENT_SERVER_PRODUCTION_URL
+        config.PROJECT_SLUGS_PRODUCTION
+      else
+        config.PROJECT_SLUGS_STAGING
+
+  lookupProjectSlug: (enabledExperiments, experimentName) ->
+    thisProjectSlug for thisProjectSlug, experimentsForThisSlug of enabledExperiments when experimentName in experimentsForThisSlug
+
+  getProjectSlugForExperiment: (experimentName) ->
+    @ensureEnvironmentSet()
+    switch @EXPERIMENT_SERVER_URL_TO_USE
+      when @EXPERIMENT_SERVER_PRODUCTION_URL
+        @lookupProjectSlug config.ENABLED_EXPERIMENTS_PRODUCTION, experimentName
+      else
+        @lookupProjectSlug config.ENABLED_EXPERIMENTS_STAGING, experimentName
+
+  # At the start (or resume) of an experiment, make sure geordi gets updated.
+  #
+  # (Note: for experiments that have a separate "registration" before first event, this would also be the place
+  # that we would do that POST to the experiment server
+  # - this isn't currently done here as we don't have an experiment that needs registration)
+  #
+  startOrResumeExperiment: (interventionMonitor, geordi) ->
+    if interventionMonitor?.latestFromSugar and "experiment_name" of interventionMonitor?.latestFromSugar
+      experimentName = interventionMonitor?.latestFromSugar["experiment_name"]
+      cohort = interventionMonitor?.latestFromSugar["cohort"]
+      geordi?.remember
+        experiment: experimentName
+        cohort: cohort
+      if interventionMonitor?.latestFromSugar["seq_of_next_event"] is 1
+        if Object.keys(interventionMonitor?.latestFromSugar["session_histories"]).length > 0
+          @logExperimentState geordi, interventionMonitor?.latestFromSugar, "experimentResume"
+        else
+          @logExperimentState geordi, interventionMonitor?.latestFromSugar, "experimentStart"
+
+  # TODO Design a better way for Geordi to handle long "data" field values (currently it's VARCHAR(512) set by Loopback
+  # - so we need to compress the string as much as possible and ensure it is never longer than 512 or that will cause a
+  # 500 error. Note: Geordi server will be updated: https://github.com/zooniverse/geordi/issues/87. When it is, these
+  # four methods can be removed.
+  #
+  simplifyParticipantDataForLogging: (participantData, experimentState) ->
+    simpleData = {}
+    fieldsToInclude = ["current_session_id","current_session_history","seq_of_next_event","next_event","intervention_time","active"]
+    for field in fieldsToInclude
+      @minimallyStoreField participantData, field, simpleData
+    # only store session plan upon start or resume
+    #if experimentState is "experimentStart" or experimentState is "experimentResume"
+    #  @minimallyStoreField participantData, "current_session_plan", simpleData
+    simpleData
+
+  # update simpleData with a simplified version of this field's original data
+  minimallyStoreField: (originalData, fieldname, simpleData) ->
+    fieldnameShorteningMap = {
+      current_session_id: "sessID"
+      current_session_history: "hist"
+      current_session_plan: "plan"
+      seq_of_next_event: "next_evt_pos"
+      intervention_time: "ivn_next"
+    }
+    valueCompressionMap = {
+      intervention: "i"
+      classification: "c"
+      "-question-": "qu"
+      "-statement-": "st"
+      gamisation: "gam"
+      valued: "val"
+      learning: "lrn"
+    }
+    if fieldname of originalData
+      compressedFieldname = fieldname
+      if fieldname of fieldnameShorteningMap
+        compressedFieldname = fieldnameShorteningMap[fieldname]
+      compressedValue = JSON.parse(JSON.stringify(originalData[fieldname])) # deep clone
+      if compressedValue
+        if typeof compressedValue is 'string'
+          compressedValue = @replaceAllSubStringsByRegEx compressedValue, valueCompressionMap
+        else if typeof compressedValue is 'object'
+          for subValue, index in compressedValue
+            compressedSubValue = subValue
+            if typeof subValue is 'string'
+              compressedSubValue = @replaceAllSubStringsByRegEx subValue, valueCompressionMap
+            compressedValue[index] = compressedSubValue
+      simpleData[compressedFieldname] = compressedValue
+    simpleData
+
+  replaceAllSubStringsByRegEx: (stringToModify, valueCompressionMap) ->
+    for regexStr, replacement of valueCompressionMap
+      regex = new RegExp regexStr,"gi"
+      stringToModify = stringToModify.replace regex, replacement
+    stringToModify
+
+  # .. and if it's too long, we give up.
+  safeJSON: (simplifiedData) ->
+    if simplifiedData
+      jsonString = JSON.stringify(simplifiedData)
+      if jsonString.length >= 512
+        if DEBUG
+          console.log "Too much data to post to Geordi (length #{jsonString.length}) even when simplified: "
+          console.log simplifiedData
+        jsonString = JSON.stringify {
+          error: "too_much_data"
+          details: "The data passed to Geordi was too large to store, at #{jsonString.length} characters (maximum is 512)."
+        }
+      jsonString
+    else
+      null
+
+  changeState: (triggeringEvent) ->
+    nextStateFor = {
+      classificationStart: @EXPERIMENT_STATE_CLASSIFYING # (from WHATS_NEXT or POST_CLASSIFY)
+      classificationEnd: @EXPERIMENT_STATE_POST_CLASSIFY # (from CLASSIFYING)
+      interventionStart: @EXPERIMENT_STATE_INTERVENTION_ON_SCREEN # (from POST_CLASSIFY)
+      interventionEnd: @EXPERIMENT_STATE_WHATS_NEXT # (from INTERVENTION_ON_SCREEN)
+      experimentStart: @EXPERIMENT_STATE_POST_CLASSIFY # (from null)
+      experimentResume: @EXPERIMENT_STATE_POST_CLASSIFY # (from null)
+      experimentEnd: @EXPERIMENT_STATE_FINISHED # (from anywhere)
+      # interventionDetected doesn't change the state
+    }
+    if triggeringEvent of nextStateFor
+      @currentExperimentState = nextStateFor[triggeringEvent]
+
+  # experimentState is "experimentStart", "classificationStart", "classificationEnd", "interventionStart", "interventionEnd"
+  logExperimentState: (geordi, participantData, experimentState) ->
+    @changeState experimentState
+    simpleData = null
+    if participantData?
+      simpleData = @simplifyParticipantDataForLogging participantData, experimentState
+    geordi.logEvent
+      type: experimentState
+      relatedID: "experimentState"
+      data: @safeJSON simpleData
+
+  # log some experimental data to geordi, with the specified event type
+  logExperimentData: (geordi, eventType, eventData) ->
+    geordi.logEvent {
+      type: eventType
+      relatedID: "experimentData",
+      data: JSON.stringify(eventData)
+    }
+         
+  # check if this project has an experiment enabled. Return experiment_name if so.
+  #
+  # (If it does, it should be notifying experiment server of its classifications, 
+  #  which will register it or progress it)
+  checkForExperiment: (projectSlug) ->
+    enabledExperiments = @getEnabledExperiments()
+    if projectSlug of enabledExperiments
+      enabledExperiments[projectSlug]
+
+  # type = "classification" or "intervention" (corresponding to Experiment Server endpoints)
+  # id is the classification_id or intervention_id correspondingly
+  postDataToExperimentServer: (interventionMonitor, geordi, experimentName, userID, sessionID, resourceType, id) ->
+    @ensureEnvironmentSet()
+
+    if not sessionID?
+      sessionID = getSessionID()
+
+    postPath = "/experiment/#{experimentName}/user/#{userID}/session/#{sessionID}/#{resourceType}/#{id}"
+    postURL = "#{@EXPERIMENT_SERVER_URL_TO_USE}#{postPath}"
+    fetch postURL, {
+      method: 'POST'
+      headers: new Headers()
+      mode: 'cors'
+      cache: 'default'
+    }
+    .then (response) =>
+      if response.ok
+        if DEBUG then console.log "Successful post to Experiment Server #{postURL}: #{response.status} #{response.statusText}"
+        geordiEventType = "#{resourceType}End"
+        @logExperimentState geordi, interventionMonitor?.latestFromSugar, geordiEventType # "interventionEnd" or "classificationEnd"
+      else
+        if DEBUG then console.log "Error posting to Experiment Server: #{response.status} #{response.statusText}"
+        #TODO log Experiment Error
+
+  optOutThisUser: (interventionMonitor, geordi, experimentName, userID) ->
+    postPath = "/users/#{userID}/optout"
+    postURL = "#{@EXPERIMENT_SERVER_URL_TO_USE}#{postPath}"
+    params = new URLSearchParams()
+    params.append 'experiment_name', experimentName
+    params.append 'user_id', userID
+    params.append 'project', @getProjectSlugForExperiment experimentName
+    fetch postURL, {
+      method: 'POST'
+      body: params
+      headers: new Headers()
+      mode: 'cors'
+      cache: 'default'
+    }
+    .then (response) =>
+      if response.ok
+        if DEBUG then console.log "Successful opt out posted to Experiment Server #{postURL}: #{response.status} #{response.statusText}"
+        @logExperimentState geordi, interventionMonitor?.latestFromSugar, "experimentOptOut"
+      else
+        if DEBUG then console.log "Error posting opt out to Experiment Server: #{response.status} #{response.statusText}"
+        #TODO log Experiment Error
+      interventionMonitor.clearSugarLatest()
+
+  getInterventionFromConfig: (projectSlug, experimentName, interventionID) ->
+    enabledExperiments = @getEnabledExperiments()
+    interventionDetails = @getInterventionDetails()
+    if experimentName in enabledExperiments[projectSlug] and projectSlug of interventionDetails
+      if experimentName of interventionDetails[projectSlug]
+        if interventionID of interventionDetails[projectSlug][experimentName]
+          interventionDetails[projectSlug][experimentName][interventionID]
+
+  constructInterventionFromSugarData: (sugarData) ->
+    if "experiment_name" of sugarData
+      experimentName = sugarData["experiment_name"]
+      projectSlug = @getProjectSlugForExperiment(experimentName)
+      switch experimentName
+        when config.COMET_HUNTERS_VOLCROWE_EXPERIMENT
+          if "intervention_time" of sugarData
+            if sugarData["intervention_time"]
+              if "next_event" of sugarData
+                interventionID = sugarData["next_event"]
+                @getInterventionFromConfig projectSlug, experimentName, interventionID
+        else
+          console.log "Intervention Requested for Unsupported Experiment '#{experimentName}'"
+
+module.exports = new ExperimentsClient

--- a/app/lib/experiments-config.coffee
+++ b/app/lib/experiments-config.coffee
@@ -1,0 +1,190 @@
+intervention_config = require './intervention-config'
+
+config = {
+  CLASSIFICATION_MARKER: "classification"
+
+  PROJECT_SLUGS_PRODUCTION: {
+    COMET_HUNTERS: "mschwamb/hsc-comet-hunters-prototype"
+#   when we go live, switch to:
+#   COMET_HUNTERS: "mschwamb/comet-hunters"
+  }
+
+  PROJECT_SLUGS_STAGING: {
+    PLANET_FOUR_TERRAINS: "mschwamb/planet-four-terrains"
+  }
+
+  COMET_HUNTERS_VOLCROWE_EXPERIMENT: "CometHuntersVolcroweExperiment1"
+}
+
+config.ENABLED_EXPERIMENTS_STAGING = {
+  "#{ config.PROJECT_SLUGS_STAGING['PLANET_FOUR_TERRAINS']}": [config.COMET_HUNTERS_VOLCROWE_EXPERIMENT]
+}
+
+config.ENABLED_EXPERIMENTS_PRODUCTION = {
+  "#{ config.PROJECT_SLUGS_PRODUCTION['COMET_HUNTERS']}": [config.COMET_HUNTERS_VOLCROWE_EXPERIMENT]
+}
+
+COMET_HUNTERS_VOLCROWE_EXPERIMENT_INTERVENTIONS = {
+  "#{ config.COMET_HUNTERS_VOLCROWE_EXPERIMENT }": {
+    "valued-statement-1": {
+      title: "Interesting Fact",
+      body: "On average, we receive a total of 1900 classifications on this project every day."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "valued-statement-2": {
+      title: "Interesting Fact",
+      body: "The average contributor to this project has classified a total of 37 images."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "valued-statement-3": {
+      title: "Interesting Fact",
+      body: "Your input is extremely valuable to the project. Thanks very much, please keep going!"
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "valued-statement-4": {
+      title: "Interesting Fact",
+      body: "On average, this project receives classifications from 365 individual contributors every week."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "valued-statement-5": {
+      title: "A Quick Thought",
+      body: "Submitting a few more classifications will make a huge difference to the outcome of this project. Thanks very much, please keep going!"
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "gamisation-statement-1": {
+      title: "Interesting Fact",
+      body: "Some users as they classify on this project have fun by sharing images of comets that look like other things on Talk such as <a href='https://www.zooniverse.org/projects/mschwamb/comet-hunters/talk/211/37406'>hearts</a> or <a href='https://www.zooniverse.org/projects/mschwamb/comet-hunters/talk/211/48914'>flowers</a>."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "gamisation-statement-2": {
+      title: "A Quick Thought",
+      body: "Remember, the data you contribute to this project is used to advance scientific knowledge.  Please take your time and make sure you contribute your best possible guess."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "gamisation-statement-3": {
+      title: "A Quick Thought",
+      body: "We hope you enjoy looking at these images; scientific research should be fun."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "gamisation-statement-4": {
+      title: "A Quick Thought",
+      body: "If you’re starting to feel bored with this project and would like a break, why not contribute some classifications to <a href='/projects/'>another Zooniverse project</a>?"
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "gamisation-statement-5": {
+      title: "A Quick Thought",
+      body: "Why not take a break if you feel you need one?"
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "learning-statement-1": {
+      title: "Interesting Fact",
+      body: "Asteroids are small rocky bodies left over from the construction zones that the planets in our Solar System formed from."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "learning-statement-2": {
+      title: "Interesting Fact",
+      body: "The asteroids you review on Comet Hunters orbit between Mars and Jupiter roughly at 2-5 times the distance between the Earth and the Sun."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "learning-statement-3": {
+      title: "Interesting Fact",
+      body: "Buried water ice that has been freshly exposed is thought to be responsible for the cometary-like activity on main-belt comets. It is thought that ancient cousins (in other words, icy asteroids) of today's main-belt comets helped deliver water to the young Earth."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "learning-statement-4": {
+      title: "Interesting Fact",
+      body: "During an outburst, dust and dirt are ejected off the surface of the asteroid. Sunlight then pushes these small particles into long streaks and complex shapes that we call a main-belt comet's tail."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "learning-statement-5": {
+      title: "Interesting Fact",
+      body: "Main-belt comets are a new class of minor planets recently discovered in our Solar System. Less than 20 have been discovered to date."
+      type: intervention_config.INTERVENTION_TYPES.STATEMENT
+    }
+    "valued-question-1": {
+      title: "A Quick Question",
+      body: "How do you know that you are making a valuable contribution to this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "valued-question-2": {
+      title: "A Quick Question",
+      body: "How much money do you think you should receive for each of your classifications if you were being paid to participate in this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "valued-question-3": {
+      title: "A Quick Question",
+      body: "How would you feel if we told you that you've contributed more classifications today than most other users do in a day?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "valued-question-4": {
+      title: "A Quick Question",
+      body: "How many other users do you think have contributed to this project today?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "valued-question-5": {
+      title: "A Quick Question",
+      body: "How would you feel if we told you that your classifications are usually more accurate than the average user?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "gamisation-question-1": {
+      title: "A Quick Question",
+      body: "Does this feel like a game? Explain why or how it does/doesn't feel like one."
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "gamisation-question-2": {
+      title: "A Quick Question",
+      body: "To what extent do you think you would classify more images if you won things or were thanked or rewarded?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "gamisation-question-3": {
+      title: "A Quick Question",
+      body: "When you’re classifying, what sort of things put you off or make you bored?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "gamisation-question-4": {
+      title: "A Quick Question",
+      body: "What do you think about the amount of time it takes to complete one classification?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "gamisation-question-5": {
+      title: "A Quick Question",
+      body: "Do you ever feel like you lose yourself in the project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "learning-question-1": {
+      title: "A Quick Question",
+      body: "What would help you to learn more while classifying?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "learning-question-2": {
+      title: "A Quick Question",
+      body: "What have you learned about comets since starting this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "learning-question-3": {
+      title: "A Quick Question",
+      body: "Which other sources of information on comets have you looked at since starting this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "learning-question-4": {
+      title: "A Quick Question",
+      body: "What knowledge of comets have you shared with others since starting this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+    "learning-question-5": {
+      title: "A Quick Question",
+      body: "Is there anything you would like to learn about comets by participating in this project?"
+      type: intervention_config.INTERVENTION_TYPES.QUESTION
+    }
+  }
+}
+
+config.INTERVENTION_DETAILS_PRODUCTION = {
+  "#{ config.PROJECT_SLUGS_PRODUCTION['COMET_HUNTERS']}": COMET_HUNTERS_VOLCROWE_EXPERIMENT_INTERVENTIONS
+}
+
+config.INTERVENTION_DETAILS_STAGING = {
+  "#{ config.PROJECT_SLUGS_STAGING['PLANET_FOUR_TERRAINS']}": COMET_HUNTERS_VOLCROWE_EXPERIMENT_INTERVENTIONS
+}
+
+module.exports = config

--- a/app/lib/geordi-logger.coffee
+++ b/app/lib/geordi-logger.coffee
@@ -2,7 +2,11 @@ GeordiClient = require 'zooniverse-geordi-client'
 
 class GeordiLogger # Make calls to the Geordi API to log user activity
 
-  @tokens = ['zooHome', 'zooTalk', 'zooniverse/gravity-spy']
+  @tokens = ['zooHome', 'zooTalk', 'zooniverse/gravity-spy', 'mschwamb/hsc-comet-hunters-prototype']
+  # when we go live, switch to:
+  # @tokens = ['zooHome', 'zooTalk', 'zooniverse/gravity-spy', 'mschwamb/comet-hunters']
+  # during dev (for staging):
+  # @tokens = ['zooHome', 'zooTalk', 'zooniverse/gravity-spy', 'mschwamb/planet-four-terrains']
 
   keys:
     projectToken: 'zooHome'

--- a/app/lib/intervention-config.coffee
+++ b/app/lib/intervention-config.coffee
@@ -1,0 +1,8 @@
+config = {
+  INTERVENTION_TYPES: {
+    QUESTION: "question"
+    STATEMENT: "statement"
+  }
+}
+
+module.exports = config

--- a/app/lib/intervention-monitor.coffee
+++ b/app/lib/intervention-monitor.coffee
@@ -1,0 +1,51 @@
+# Monitors interventions coming via Sugar, for example from Experiment Server, throughout the app
+
+{sugarClient} = require 'panoptes-client/lib/sugar'
+EventEmitter = require 'events'
+
+DEBUG = false
+
+# for detecting interventions that have been posted via Sugar (e.g. by the Experiment Server)
+class InterventionMonitor extends EventEmitter
+  project_slug: null
+
+  sugarEvent: null
+
+  constructor: ->
+    @sugarEvent = new Event 'sugarExperimentEvent'
+    @startListening()
+
+  latestFromSugar: null
+
+  setProjectSlug: (project_slug) ->
+    @project_slug = project_slug
+
+  clearSugarLatest: ->
+    @latestFromSugar = null
+    
+  shouldShowIntervention: ->
+    return (@latestFromSugar? and @latestFromSugar["intervention_time"] and @latestFromSugar["next_event"] and @latestFromSugar["active"])
+
+  startListening: ->
+    sugarClient.on 'experiment', @sugarListener
+
+  stopListening: ->
+    sugarClient.off 'experiment', @sugarListener
+
+  sugarListener: (sugarMessage) =>
+    sugarPayload = sugarMessage.data
+    intervention_target_project = sugarPayload.section
+    # intervention only valid if it's for the right project
+    if @project_slug? and intervention_target_project == @project_slug
+      @latestFromSugar = sugarPayload.message
+      if @latestFromSugar["active"]==true
+        if @latestFromSugar["intervention_time"]==true
+          if DEBUG then console.log "Sugar reports that an intervention is required:\n",@latestFromSugar
+          this.emit 'interventionRequested', @latestFromSugar
+        else
+          if DEBUG then console.log "Update from Sugar - no intervention required though:\n",@latestFromSugar
+          this.emit 'classificationTaskRequested', @latestFromSugar
+      else
+        if DEBUG then console.log "Sugar's experimental data ignored as participant is marked inactive:\n",@latestFromSugar
+
+module.exports = new InterventionMonitor

--- a/app/lib/intervention.cjsx
+++ b/app/lib/intervention.cjsx
@@ -1,0 +1,116 @@
+React = require 'react'
+interventionMonitor = require './intervention-monitor'
+experimentsClient = require './experiments-client'
+config = require './intervention-config'
+{getSessionID} = require '../lib/session'
+Dialog = require 'modal-form/dialog'
+{Link} = require 'react-router'
+
+Intervention = React.createClass
+
+  contextTypes:
+    geordi: React.PropTypes.object
+
+  propTypes:
+    experimentName: React.PropTypes.string.isRequired
+    sessionID: React.PropTypes.string.isRequired
+    interventionID: React.PropTypes.string.isRequired
+    interventionDetails: React.PropTypes.object.isRequired
+    disableInterventionFunction: React.PropTypes.func.isRequired
+
+  endIntervention: ->
+    experimentsClient.postDataToExperimentServer interventionMonitor,
+                                                 @context.geordi,
+                                                 @props.experimentName,
+                                                 @props.user.id,
+                                                 @props.sessionID,
+                                                 "intervention",
+                                                 @props.interventionID
+
+  skipIntervention: (event) ->
+    logData = {
+      sessID: @props.sessionID
+      ivnID: @props.interventionID
+      cancelled: true
+    }
+    experimentsClient.logExperimentData @context.geordi, 'skipIntervention', logData
+    @endIntervention()
+
+  answerQuestion: (event) ->
+    logData = {
+      sessID: @props.sessionID
+      ivnID: @props.interventionID
+      answer: document.getElementsByClassName("intervention-question")[0].value
+    }
+    experimentsClient.logExperimentData @context.geordi, 'interventionResponse', logData
+    @endIntervention()
+    event.target.disabled = true
+    event.preventDefault()
+
+  endStatement: (event) ->
+    @endIntervention()
+    event.target.disabled = true
+    event.preventDefault()
+
+  componentWillMount: ->
+    if experimentsClient.currentExperimentState isnt experimentsClient.EXPERIMENT_STATE_INTERVENTION_ON_SCREEN
+      experimentsClient.logExperimentState @context.geordi, interventionMonitor?.latestFromSugar, "interventionStart"
+
+  getBodyMarkup: (html) ->
+    { __html: html }
+
+  logLinkClick: (event) ->
+    logData = {
+      sessID: @props.sessionID
+      ivnID: @props.interventionID
+      linkAddress: event.target.getAttribute("href")
+    }
+    experimentsClient.logExperimentData @context.geordi, 'interventionLinkClicked', logData
+
+  optOut: ->
+    experimentsClient.optOutThisUser interventionMonitor, @context.geordi, @props.experimentName, @props.user.id
+    @props.disableInterventionFunction()
+
+  componentDidMount: ->
+    interventionBody = document.getElementsByClassName("intervention-body")[0]
+    linksInInterventions = interventionBody.getElementsByTagName("a")
+    for link in linksInInterventions
+      link.addEventListener("click", @logLinkClick)
+
+  render: ->
+    <Dialog style={maxWidth: '30%', paddingLeft: '1.2em', paddingRight: '1.2em', top: '20%'} tag="form" className="intervention" closeButton={true} onCancel={@skipIntervention}>
+      <h3 style={paddingTop: '0.7em'} className="intervention-title">{@props.interventionDetails.title}:</h3>
+      <p dangerouslySetInnerHTML={@getBodyMarkup(@props.interventionDetails.body)} className="intervention-body"/>
+      {if @props.interventionDetails.type is config.INTERVENTION_TYPES.QUESTION
+        <textarea style={width: '95%', height:'5em', padding:'0.5em', lineHeight: '1.35em', fontSize:'medium'} placeholder="Enter your answer here" className="intervention-question"/>}
+      <nav className="task-nav" style={textAlign:"center",paddingBottom:'1em',paddingTop:'1.3em'}>
+        {if @props.interventionDetails.type is config.INTERVENTION_TYPES.STATEMENT
+          <button type="submit" onClick={@endStatement} className="intervention-ok continue major-button" style={margin: "0 auto"}>
+              <span>Continue</span>
+          </button>}
+        {if @props.interventionDetails.type is config.INTERVENTION_TYPES.QUESTION
+          <span style={margin: "0 auto"}>
+            <button type="button" onClick={@skipIntervention} className="intervention-cancel standard-button">
+              <span>Skip this question</span>
+            </button>
+            <button style={marginLeft: "1em"} type="submit" onClick={@answerQuestion} className="intervention-submit continue major-button">
+              <span>Submit my answer</span>
+            </button>
+          </span>}
+      </nav>
+      <hr/>
+      <p className="interventions-info" style={fontSize: 'x-small'}>
+        {if @props.interventionDetails.type is config.INTERVENTION_TYPES.STATEMENT
+          <span>
+            We are showing you this message as a trial of a new feature which aims to make your experience on Zooniverse projects like Comet Hunters more interesting and enjoyable.
+            If you would prefer not to receive messages like this, you can <a style={cursor:'pointer'} onClick={@optOut}>click here to opt-out</a> from all future messages.
+          </span>}
+        {if @props.interventionDetails.type is config.INTERVENTION_TYPES.QUESTION
+          <span>
+            We are asking you this question as a part of an initiative to make volunteers' experiences on Zooniverse projects like Comet Hunters more interesting and enjoyable.
+            If you would prefer not to receive questions like this, you can <a style={cursor:'pointer'} onClick={@optOut}>click here to opt-out</a> from all future questions.
+          </span>}
+      </p>
+    </Dialog>
+
+module.exports = Intervention

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -24,7 +24,7 @@ PanoptesApp = React.createClass
 
   componentWillMount: ->
     @geordiLogger = new GeordiLogger
-  
+
   componentDidMount: ->
     auth.listen 'change', @handleAuthChange
     generateSessionID()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
     "drag-reorderable": "~0.1.0",
+    "events": "~1.1.1",
     "jsplumb": "1.7.9",
     "lodash.intersection": "~3.2.0",
     "lodash.merge": "~2.4.1",


### PR DESCRIPTION
Fixes # .

Describe your changes.
# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
  Interventions are now monitored app-wide - but only detected at the start of a new classification.
  Adding data for Comet Hunters experiment, and the basic showing of title and text according to what sugar sends down in the session plan.
  Move all config to a config file. Ensure interventions only show up for the correct project.
  Update interventions such that rendering is correct whether we are expecting an intervention or a classification task.
  Statement updates from Meg
  Adding data for Comet Hunters experiment, and the basic showing of title and text according to what sugar sends down in the session plan.
  Move all config to a config file. Ensure interventions only show up for the correct project.
  Classifications can now advance the experiment. Interventions cannot yet. Updated configs to code with production vs dev.
  Update interventions such that rendering is correct whether we are expecting an intervention or a classification task.
  Statement updates from Meg
  Move code which was blocking classification save.
  Geordi logging, first pass.
  Remove isMounted, by fixing removeListener issue (thanks @eatyourgreens).
  Also, ensure experiments not initiated for non-logged-in users.
  Use camelCase
  remove unused import
  remove unnecessary `==true`
  doc tweak
  Geordi logging of all experimental events.
  Improved state management to avoid duplicate postings.
  Use fetch.
  Use camelCase.
  Address other code review comments.
  Logging of skip button and submission of question response to Geordi.
  Plug in actual values
  Add links to interventions, and geordi link tracking.
  Remove Intervention Monitor and Experiments Client from context
  Switch div to a form, and buttons to submit.
  Disable debug.
  Per Meg's request, ensure that when we initially go onto production, we use the HSC prototype project, not the live Comet Hunters project.
  Clarify comment to try and address code review comment.
  Move the check for recent interventions to the first render, and not every time, per code review comment.
  Ensure correct subject ID remembered per code review comment.
  Add key for prototype project on staging.
  Add a check around geordi subject ID remembering so we don't do it unnecessarily.
  Change the Interventions to a dialog - both to ensure summary text is never missed, and to address Joe/Meg's feedback that it needed to be more obvious.
  For now, using inline styling. Might move that to CSS file once reviewed and finalised.
  Opt out click link exists, but doesn't do anything yet.
  Tweak messaging and button colour per Meg feedback
  Enable Opt Out functionality in UI (with logging)
  Ensure we don't log for Comet Hunters (not yet) or P4T on production
  Remove references from when interventionMonitor and experimentsClient were in context
