### PR TITLE
Add "blank images" paper to publications page

### DIFF
--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -352,7 +352,10 @@ publicationCategories =
       date: "May 28, 2015"},
       {citation: "Snapshot Serengeti, high-frequency annotated camera trap images of 40 mammalian species in an African savanna, Swanson+ 2015."
       href: "http://www.nature.com/articles/sdata201526"
-      date: "June 9, 2015"}]
+      date: "June 9, 2015"},
+      {citation: "This Image Intentionally Left Blank: Mundane Images Increase Citizen Science Participation, Bowyer+ 2015."
+      href: "https://www.humancomputation.com/2015/papers/45_Paper.pdf"
+      date: "Nov 10, 2015"}]
     }
   ],
   # biology: [


### PR DESCRIPTION
Fixes # .

Hi folks, hope all are well.

I noticed that the HCOMP 2015 WIP papers are now online, so the 'blank images' paper could be added to the publications page. 

I no longer have a Zoo environment set up locally so could someone test this before approving the PR?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?